### PR TITLE
Add support for validation dataset when creating finetuned models

### DIFF
--- a/src/urim/ft/controller.py
+++ b/src/urim/ft/controller.py
@@ -421,7 +421,7 @@ class FineTuneController:
                     if ds is None:
                         continue
 
-                    dataset_hash = hash(request.train_ds)
+                    dataset_hash = hash(ds)
                     ds_path = storage_subdir("ft", "datasets") / f"{dataset_hash}.jsonl"
                     if ds_path.exists():
                         shared_inflight = any(

--- a/src/urim/ft/service.py
+++ b/src/urim/ft/service.py
@@ -51,6 +51,7 @@ class FineTuneService(ABC):
         learning_rate: float,
         batch_size: int,
         n_epochs: int,
+        validation_ds: "Dataset" | None = None,
         **kwargs: Any,
     ) -> FineTuneJob: ...
 

--- a/src/urim/ft/service.py
+++ b/src/urim/ft/service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum
@@ -22,8 +24,8 @@ class FineTuneJobStatus(Enum):
 
 class FineTuneJob:
     id: FineTuneJobId
-    created_at: "datetime"
-    updated_at: "datetime"
+    created_at: datetime
+    updated_at: datetime
     status: FineTuneJobStatus
     service_identifier: str | None
 
@@ -47,11 +49,11 @@ class FineTuneService(ABC):
         self,
         model: str,
         *,
-        train_ds: "Dataset",
+        train_ds: Dataset,
         learning_rate: float,
         batch_size: int,
         n_epochs: int,
-        validation_ds: "Dataset" | None = None,
+        validation_ds: Dataset | None = None,
         **kwargs: Any,
     ) -> FineTuneJob: ...
 

--- a/src/urim/model.py
+++ b/src/urim/model.py
@@ -48,6 +48,7 @@ async def model(
     n_epochs: int = 1,
     learning_rate: float = 1.0,
     salt: str = "",
+    validation_ds: Dataset | None = None,
     **ft_kwargs: Any,
 ) -> ModelRef:
     from urim.ft.controller import FineTuneRequest
@@ -73,6 +74,7 @@ async def model(
         batch_size=batch_size,
         n_epochs=n_epochs,
         salt=salt,
+        validation_ds=validation_ds,
         hyperparams=tuple(sorted(ft_kwargs.items(), key=lambda item: item[0])),
     )
     desc_key = request.serialize(cache_dataset=False)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds optional validation dataset to fine-tuning, threading through model API, request serialization, OpenAI job creation, and dataset caching/cleanup.
> 
> - **Fine-tuning pipeline**:
>   - Accepts `validation_ds` in `model(...)` and propagates via `FineTuneRequest` to service calls.
>   - `FineTuneRequest.serialize` now caches/records `validation_ds` hash when provided; controller passes `validation_ds` to job creation.
>   - Cleanup logic removes cached files for both `train_ds` and `validation_ds` when no longer referenced.
> - **OpenAI service**:
>   - `create_job` accepts `validation_ds`, uploads it, and sets `validation_file` on the job request.
>   - Refactors `_upload_training_file` to generic `_upload_dataset(name=...)` to handle both training and validation uploads.
> - **Service interface/types**:
>   - Extends `FineTuneService.create_job` to include `validation_ds`.
>   - Minor typing fixes (e.g., datetime annotations).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b3b2123a8f8b06f22f89486c97f91fee52ad53b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->